### PR TITLE
[Refactor] 내 프로필 메뉴 탭 자연스럽게 개선

### DIFF
--- a/Fitfty/Projects/Profile/Sources/Profile/ViewControllers/ProfileViewController.swift
+++ b/Fitfty/Projects/Profile/Sources/Profile/ViewControllers/ProfileViewController.swift
@@ -132,6 +132,9 @@ final public class ProfileViewController: UIViewController {
     }
     
     @objc func didTapMyFitftyMenu(_ sender: Any?) {
+        guard menuType == .bookmark else {
+            return
+        }
         isRefreshProfileImage = false
         collectionView.isScrollEnabled = true
         emptyView.isHidden = true
@@ -140,6 +143,9 @@ final public class ProfileViewController: UIViewController {
     }
     
     @objc func didTapBookmarkMenu(_ sender: Any?) {
+        guard menuType == .myFitfty else {
+            return
+        }
         isRefreshProfileImage = false
         collectionView.isScrollEnabled = true
         emptyView.isHidden = true

--- a/Fitfty/Projects/Profile/Sources/Profile/Views/ProfileView.swift
+++ b/Fitfty/Projects/Profile/Sources/Profile/Views/ProfileView.swift
@@ -62,10 +62,18 @@ final class ProfileView: UIView {
 }
 
 extension ProfileView {
-    func setUp(nickname: String, content: String, filepath: String?) {
+    func setUp(nickname: String, content: String, filepath: String?, refresh: Bool) {
         if let filepath = filepath {
             let url = URL(string: filepath)
-            imageView.kf.setImage(with: url)
+            if refresh {
+                imageView.kf.indicatorType = .activity
+                imageView.kf.setImage(
+                    with: url,
+                    options: [.forceRefresh]
+                )
+            } else {
+                imageView.kf.setImage(with: url)
+            }
         } else {
             imageView.image = CommonAsset.Images.profileDummy.image
         }


### PR DESCRIPTION
### 📕 Issue


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역, 변경 사항을 포함합니다.

- [x] 다른 메뉴를 누를때만 reload하게 처리 (ex)북마크메뉴선택 상태에서 북마크 누르면 반응x)
- [x] 메뉴 탭할때마다 깜빡거리는 애니메이션 해결


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

### 📱 테스트 방법

- 내 프로필탭에서 메뉴 이동 자연스러운지 확인해주시면 됩니당

### 📝 리뷰 노트


- 프로필 메뉴를 탭할때마다 프로필 이미지를 가져오면 노이지해서 viewWillAppear일때만 refresh되게 구현해 봤어요!
- 기존에 깜빡거리는 현상은 indicator의 alpha값을 0으로 주어서 해결했습니당 (찾아주신 에단 감사합니다👍)

### 🏞️ 스크린샷

> 작업 내용과 관련된 화면을 추가합니다.
